### PR TITLE
fix: process empty array

### DIFF
--- a/src/Utility/PgArrayConverter.php
+++ b/src/Utility/PgArrayConverter.php
@@ -39,9 +39,13 @@ class PgArrayConverter
                 $return[] = static::fromPg($openBraces . $part . $closeBraces, $type);
             }
         } else {
-            $parsed = str_getcsv(trim($data, '{}'));
+            $data = trim($data, '{}');
+            if (!strlen($data)) {
+                return [];
+            }
+            $parsed = str_getcsv($data);
             if ($type === 'text') {
-                $checkNulls = str_getcsv(trim($data, '{}'), ',', "\u{2007}");
+                $checkNulls = str_getcsv($data, ',', "\u{2007}");
             }
             foreach ($parsed as $i => $value) {
                 if ($value === null) {

--- a/tests/Fixture/ArraysFixture.php
+++ b/tests/Fixture/ArraysFixture.php
@@ -28,6 +28,13 @@ class ArraysFixture extends TestFixture
             'f1' => '{1.21,2.0,3}',
             'bool1' => '{true,false,1,f,null,0, TRUE}',
         ],
+        [
+            'txt1' => null,
+            'txt2' => '{}',
+            'int1' => '{}',
+            'f1' => '{}',
+            'bool1' => '{}',
+        ],
     ];
 
     /**

--- a/tests/TestCase/Database/Type/ArrayTypeTest.php
+++ b/tests/TestCase/Database/Type/ArrayTypeTest.php
@@ -33,7 +33,7 @@ class ArrayTypeTest extends TestCase
 
     public function testArray()
     {
-        $first = $this->Arrays->find()->first();
+        $first = $this->Arrays->find()->where(['txt1 IS NOT' => null])->first();
         $this->assertTrue(is_array($first->txt1));
         $this->assertEquals(5, count($first->txt1));
         $this->assertNull($first->txt1[4]);
@@ -55,7 +55,7 @@ class ArrayTypeTest extends TestCase
         $first->f1 = ['12.34', 11];
         $first->bool1 = [true, false, null, 1, 0, 'false', '', 'True'];
         $this->Arrays->save($first);
-        $first = $this->Arrays->find()->first();
+        $first = $this->Arrays->find()->where(['txt1 IS NOT' => null])->first();
         $this->assertEquals([true, false, null, true, false, false, false, true], $first->bool1);
         $this->assertEquals([12.34, 11], $first->f1);
         $this->assertEquals([12, 11], $first->int1);
@@ -67,6 +67,12 @@ class ArrayTypeTest extends TestCase
         $this->Arrays->save($second);
         $second = $this->Arrays->get($second->id);
         $this->assertNull($second->txt2);
+
+        $empty = $this->Arrays->find()->where(['txt1 IS' => null])->first();
+        $this->assertEquals([], $empty->txt2);
+        $this->assertEquals([], $empty->int1);
+        $this->assertEquals([], $empty->f1);
+        $this->assertEquals([], $empty->bool1);
     }
 
     public function testNull()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,15 +46,15 @@ Configure::write('App', [
 ]);
 
 Configure::write('Cache', [
-        '_cake_model_' => [
-            'className' => \Cake\Cache\Engine\NullEngine::class,
-            'prefix' => 'myapp_cake_model_',
-            'path' => ROOT . 'models' . DS,
-            'serialize' => true,
-            'duration' => '+1 minute',
-            'url' => env('CACHE_CAKEMODEL_URL', null),
-        ],
-    ]);
+    '_cake_model_' => [
+        'className' => \Cake\Cache\Engine\NullEngine::class,
+        'prefix' => 'myapp_cake_model_',
+        'path' => ROOT . 'models' . DS,
+        'serialize' => true,
+        'duration' => '+1 minute',
+        'url' => env('CACHE_CAKEMODEL_URL', null),
+    ],
+]);
 
 if (file_exists($root . '/config/bootstrap.php')) {
     require $root . '/config/bootstrap.php';


### PR DESCRIPTION
Fix convertion empty array (`'{}'`) to PHP, should be `[]` instead of `[null]`