### PR TITLE
fix: ignore invalid columns

### DIFF
--- a/src/Model/Behavior/UpsertBehavior.php
+++ b/src/Model/Behavior/UpsertBehavior.php
@@ -64,15 +64,15 @@ class UpsertBehavior extends Behavior
         $extra = array_filter($extra, function ($column) use ($tableColumns) {
             return in_array($column, $tableColumns);
         }, ARRAY_FILTER_USE_KEY);
-        $fields = [];
-        foreach ($data as $row) {
-            $fields = array_flip(array_flip(array_merge($fields, array_keys($row))));
-        }
+        $fields = array_reduce($data, function ($fields, $row) {
+            return array_unique(array_merge($fields, array_keys($row)));
+        }, []);
         if (!empty($updateColumns)) {
             $updateColumns = array_intersect((array)$updateColumns, $tableColumns);
             $fields = array_intersect($fields, $updateColumns);
         }
         $fields = array_unique(array_merge($uniqueKey, $fields, array_keys($extra)));
+        $fields = array_intersect($fields, $tableColumns);
         $conflictKey = implode(',', $uniqueKey);
         $epilog = "ON CONFLICT ($conflictKey)";
         if (empty($updateColumns)) {

--- a/tests/TestCase/Model/Behavior/UpsertBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UpsertBehaviorTest.php
@@ -9,7 +9,7 @@ use Cake\TestSuite\TestCase;
 class UpsertBehaviorTest extends TestCase
 {
     /**
-     * @var \Cake\ORM\Table
+     * @var \Cake\ORM\Table|\Voronoy\PgUtils\Model\Behavior\UpsertBehavior
      */
     public $Articles;
 
@@ -121,7 +121,7 @@ class UpsertBehaviorTest extends TestCase
     {
         $records = [
             ['id' => 1, 'title' => 'Article 1 Nod'],
-            ['id' => 2, 'title' => 'Article 2 Mod'],
+            ['id' => 2, 'title' => 'Article 2 Mod', 'invalid_column' => 1],
             ['title' => 'New Article'],
             ['title' => 'New Article 2'],
         ];


### PR DESCRIPTION
PDO triggers an error if the data array contains columns that are not a table columns. The fix allows to pass any columns, but behavior will ignore them